### PR TITLE
fix: redesign layout to fit viewport without scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # Claude notes
 claude.md
+ISSUE_TEMPLATE.md

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,303 @@
+# Issues & Feature Suggestions
+
+---
+
+## Phase 1 — Fix the Foundation
+
+### - [ ] 1. Redesign layout to eliminate excessive vertical scrolling
+
+#### Branch
+`fix/layout-redesign`
+
+#### Why
+The app requires scrolling to see stats and algorithm info, which defeats the purpose of a real-time visualizer. Everything should be visible at once.
+
+#### Files
+- `src/App.tsx` — restructure the top-level grid into a full-viewport layout
+- `src/components/Header.tsx` — make compact and horizontal
+- `src/components/VisualizationArea.tsx` — remove redundant `lg:col-span-2`, let parent control sizing
+- `src/components/visualizers/SortingVisualizer.tsx` — remove hardcoded `width={800} height={400}`, fill container
+- `src/components/visualizers/GridVisualizer.tsx` — remove hardcoded `width={1000} height={600}`, fill container
+- `src/hooks/useVisualizerRenderer.ts` — accept dynamic dimensions from container instead of props
+- `src/hooks/useGridRenderer.ts` — accept dynamic dimensions from container instead of props
+- `src/components/StatisticsDisplay.tsx` — integrate into the sidebar Card instead of a separate grid row
+- `src/components/controls/ModeSelector.tsx` — move into the header bar
+
+#### Tasks
+1. [ ] Restructure `App.tsx`: replace `min-h-screen p-8` with `h-screen overflow-hidden flex flex-col`. Replace the `grid-cols-3` layout with a two-column layout (flexible visualizer + fixed-width ~300px sidebar). Move `ModeSelector` out of the sidebar Card and into the `Header`
+2. [ ] Rework `Header.tsx`: change from centered vertical stack to `flex justify-between items-center` horizontal bar. Title on the left, mode selector on the right. Reduce vertical space
+3. [ ] Make `SortingVisualizer.tsx` responsive: remove hardcoded width/height props. Wrap canvas in a container div that fills available space. Use `ResizeObserver` to read container dimensions and pass them to the canvas and `useVisualizerRenderer`
+4. [ ] Make `GridVisualizer.tsx` responsive: same approach as task 3. Remove hardcoded width/height, use `ResizeObserver` on container
+5. [ ] Update `useVisualizerRenderer.ts` and `useGridRenderer.ts` to work with dynamic dimensions from ResizeObserver rather than static props
+6. [ ] Move `StatisticsDisplay` into the sidebar Card in `App.tsx` — render it as a section within `CardContent` instead of a standalone Card in a separate grid row
+7. [ ] Clean up `VisualizationArea.tsx` — remove the `lg:col-span-2` class since the parent now controls the grid layout
+8. [ ] Add `overflow-y-auto` to the sidebar so controls scroll internally in pathfinding mode (which has more controls) rather than pushing the page
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] `pnpm lint` passes
+- [ ] No hardcoded `width` or `height` props remain on canvas visualizer components
+- [ ] `StatisticsDisplay` renders inside the sidebar, not as a separate grid row
+- [ ] `ModeSelector` renders inside the header, not inside the sidebar
+- [ ] Root container uses `h-screen` and `overflow-hidden`
+- [ ] [Visual] Entire app fits in viewport on 1920x1080 in both sorting and pathfinding modes without scrolling
+- [ ] [Visual] Canvas resizes when browser window resizes
+
+#### Constraints
+- Do NOT refactor hooks beyond changing how they receive width/height
+- Do NOT change algorithm execution logic, playback logic, or state management
+- Do NOT change the visual appearance of controls (spacing, button styles, etc.) — only their placement
+- Agent's discretion on exact Tailwind classes and whether to use `ResizeObserver` directly or a small hook wrapper
+
+---
+
+### - [ ] 2. Canvas overflows on smaller screens and mid-size viewports
+
+#### Branch
+`fix/canvas-overflow`
+
+#### Why
+On viewports smaller than the hardcoded canvas dimensions (800x400 sorting, 1000x600 grid), the canvas overflows its container and gets clipped or causes horizontal scroll.
+
+#### Files
+- `src/components/visualizers/SortingVisualizer.tsx` — canvas sizing
+- `src/components/visualizers/GridVisualizer.tsx` — canvas sizing
+- `src/hooks/useVisualizerRenderer.ts` — rendering at correct scale
+- `src/hooks/useGridRenderer.ts` — rendering and mouse coordinate mapping at correct scale
+
+#### Tasks
+1. [ ] If issue #1 (layout redesign) is done first, this may already be resolved by the ResizeObserver approach. Verify by testing at 1366x768 and 1024x768 viewports
+2. [ ] If not resolved: ensure canvas elements have `max-w-full` and scale down proportionally within their container using CSS `object-fit` or by setting canvas dimensions from container size
+3. [ ] Verify mouse coordinate mapping in `useGridRenderer.ts` still works correctly when the canvas CSS size differs from its internal resolution (the existing `scaleX`/`scaleY` logic on lines 88-89 should handle this, but verify)
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] No horizontal scrollbar appears at any viewport width >= 1024px
+- [ ] [Visual] Canvas scales down proportionally at 1366x768 viewport
+- [ ] [Visual] Grid wall drawing and start/end dragging still work correctly after scaling
+
+#### Constraints
+- Do NOT change the canvas rendering logic (bar drawing, cell drawing, colors)
+- Do NOT change mouse event handling logic beyond coordinate mapping
+- This issue may be fully resolved by issue #1 — check first before making additional changes
+
+---
+
+### - [ ] 3. Algorithm code panel doesn't scroll for longer implementations
+
+#### Branch
+`fix/code-panel-scroll`
+
+#### Why
+When "View Code" is toggled on in `AlgorithmInfoCard`, longer algorithm implementations (like merge sort or A*) overflow the container and get cut off.
+
+#### Files
+- `src/components/AlgorithmInfoCard.tsx` — the code display section (lines 37-45)
+
+#### Tasks
+1. [ ] Add `max-h-64 overflow-y-auto` to the `<div>` wrapping the `<pre><code>` block (the div at line 38 with class `bg-muted p-4 rounded-md overflow-x-auto`)
+2. [ ] Verify that `overflow-x-auto` (already present) still works for horizontal scroll on wide lines
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] The code block has a visible max height and scrolls vertically for long algorithms
+- [ ] Horizontal scrolling still works for wide lines
+- [ ] [Visual] Toggle "View Code" on merge sort and A* — both scroll rather than expanding the card indefinitely
+
+#### Constraints
+- Only touch the code display `<div>` — do NOT restructure the rest of `AlgorithmInfoCard`
+- Do NOT change the code content or formatting
+
+---
+
+### - [ ] 4. No error boundaries — algorithm or rendering failures crash the app silently
+
+#### Branch
+`feat/error-boundary`
+
+#### Why
+If an algorithm throws (e.g., bad grid input) or canvas rendering fails, the entire React tree unmounts with a white screen and no feedback. An error boundary should catch this and show a recoverable message.
+
+#### Files
+- Create `src/components/ErrorBoundary.tsx` — new file, React error boundary class component
+- `src/App.tsx` — wrap the visualization area and sidebar with the error boundary
+
+#### Tasks
+1. [ ] Create `src/components/ErrorBoundary.tsx`: a class component implementing `componentDidCatch` and `getDerivedStateFromError`. When an error is caught, render a Card with the error message and a "Reset" button that clears the error state
+2. [ ] In `App.tsx`, wrap the main grid layout (visualizer + sidebar) with `<ErrorBoundary>`. Do NOT wrap the Header — it should remain visible even when the visualizer crashes
+3. [ ] The reset button in the error boundary should call `setState({ hasError: false })` to re-mount the children — the hooks will re-initialize with fresh state automatically
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] `pnpm lint` passes
+- [ ] `ErrorBoundary.tsx` exists and exports a class component with `componentDidCatch`
+- [ ] The error boundary wraps the main content in `App.tsx` but not the Header
+- [ ] [Manual] Temporarily throw an error in a sorting algorithm's `generate` function — the app shows an error message instead of a white screen, and clicking reset recovers
+
+#### Constraints
+- Do NOT add error boundaries around individual controls — one boundary around the main content is enough
+- Do NOT add try/catch inside algorithm implementations — the boundary handles React rendering errors
+- Do NOT install an error reporting library — just local UI recovery
+- Keep the error UI minimal: use the existing `Card` component, a short message, and a reset button
+
+---
+
+### - [ ] 5. Add dark mode toggle
+
+#### Branch
+`feat/dark-mode`
+
+#### Why
+Dark mode CSS variables already exist in `src/index.css` (the `.dark` class on lines 34-59) but there's no way to toggle it. Most developer tools default to dark mode.
+
+#### Files
+- `src/components/Header.tsx` — add the toggle button
+- `src/index.css` — dark theme variables already defined, no changes needed
+- `src/hooks/useVisualizerRenderer.ts` — hardcoded `#ffffff` text color (line 43) won't work on light background in dark mode
+- `src/hooks/useGridRenderer.ts` — hardcoded `#e5e7eb` grid lines (line 69) may need updating
+- `src/utils/colorUtils.ts` — check if any hardcoded colors clash with dark mode
+
+#### Tasks
+1. [ ] Add a dark mode toggle button to `Header.tsx` using a Sun/Moon icon from `lucide-react`. On click, toggle the `dark` class on `document.documentElement`
+2. [ ] Persist the preference to `localStorage` under key `codetrace-theme`. On mount, read from localStorage (default to system preference via `prefers-color-scheme` if no stored value)
+3. [ ] Fix the hardcoded `#ffffff` fill color for bar value labels in `useVisualizerRenderer.ts` line 43 — read from a CSS variable or use a color that works on both light and dark canvas backgrounds
+4. [ ] Check `useGridRenderer.ts` grid line color `#e5e7eb` (line 69) and `colorUtils.ts` — update any hardcoded colors that clash with dark mode backgrounds
+5. [ ] Verify the existing `.dark` CSS variables in `index.css` produce a good result with all existing components (Cards, buttons, selects, sliders). shadcn components should inherit automatically
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] `pnpm lint` passes
+- [ ] A toggle button exists in the header that switches between light and dark mode
+- [ ] Preference persists across page reloads via localStorage
+- [ ] No hardcoded colors in canvas renderers that break in dark mode
+- [ ] [Visual] All UI elements (cards, buttons, selects, sliders) render correctly in dark mode
+- [ ] [Visual] Sorting visualizer bar labels are readable in both modes
+- [ ] [Visual] Grid visualizer lines and cells are visible in both modes
+
+#### Constraints
+- Do NOT install `next-themes` or similar — this is simple enough with a class toggle + localStorage
+- Do NOT redesign the color palette — use the existing `.dark` variables from `index.css`
+- Do NOT change component structure — only add the toggle and fix hardcoded canvas colors
+- Agent's discretion on the icon used (Sun/Moon, monitor icon, etc.)
+
+---
+
+### - [ ] 6. Add keyboard shortcuts (spacebar play/pause, arrow keys step, R reset)
+
+#### Branch
+`feat/keyboard-shortcuts`
+
+#### Why
+Power users and anyone following along with a visualization need keyboard control. Reaching for the mouse to step forward breaks flow.
+
+#### Files
+- `src/App.tsx` — add a `useEffect` with a `keydown` listener
+- `src/hooks/useVisualizationControls.ts` — provides `play`, `pause`, `stepForward`, `stepBackward`, `handleReset`, and `isPlaying` which the listener will call
+
+#### Tasks
+1. [ ] Add a `useEffect` in `App.tsx` that registers a global `keydown` event listener on `window`. Map the following keys:
+   - `Space` → toggle play/pause (call `controls.play()` or `controls.pause()` based on `controls.isPlaying`)
+   - `ArrowRight` → `controls.stepForward()`
+   - `ArrowLeft` → `controls.stepBackward()`
+   - `r` or `R` → `controls.handleReset()`
+2. [ ] In the event handler, call `e.preventDefault()` for Space (to prevent page scroll) but NOT for arrow keys when an input/select is focused. Check `document.activeElement?.tagName` — if it's `INPUT`, `SELECT`, or `TEXTAREA`, ignore the keypress to avoid interfering with form controls
+3. [ ] Clean up the listener in the useEffect return function
+
+#### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] `pnpm lint` passes
+- [ ] Pressing Space toggles play/pause when no input is focused
+- [ ] Arrow keys step forward/backward when no input is focused
+- [ ] R key resets the visualization when no input is focused
+- [ ] Keyboard shortcuts do NOT fire when a select dropdown or slider is focused
+- [ ] No page scroll occurs when pressing Space
+
+#### Constraints
+- Do NOT install a keyboard shortcut library — this is a single `useEffect` with a `keydown` listener
+- Do NOT modify `useVisualizationControls` or `usePlaybackAnimation` — call the existing returned functions
+- Do NOT add a keyboard shortcut help overlay/modal (that's a future issue)
+- Keep the listener in `App.tsx` — do NOT create a separate hook for this
+
+---
+
+## Phase 2 — Make Sorting Best-in-Class
+
+### - [ ] Add sound/audio feedback mapped to array element values during sorting
+### - [ ] Add statistics to all sorting algorithms
+### - [ ] Let users input a custom array instead of only random generation
+### - [ ] Add reverse-sorted and few-unique-values array presets
+### - [ ] Add Heap Sort
+### - [ ] Add Counting Sort
+### - [ ] Add Radix Sort
+### - [ ] Add Shell Sort
+### - [ ] Side-by-side algorithm comparison mode (race two algorithms on the same data)
+
+---
+
+## Phase 3 — Make Pathfinding Best-in-Class
+
+### - [ ] Add weighted terrain cells with different traversal costs
+### - [ ] Add Greedy Best-First Search
+### - [ ] Add Bidirectional BFS for pathfinding
+### - [ ] Add Jump Point Search (JPS) for grid pathfinding
+### - [ ] Add more maze generation algorithms (Eller's, Kruskal's, Wilson's, Aldous-Broder)
+### - [ ] Add fog-of-war mode that only reveals cells as the algorithm visits them
+### - [ ] Add maze-solving challenge mode with timer and scoring
+
+---
+
+## Phase 4 — New Visualization Modes
+
+### - [ ] Tree visualization mode (BST, AVL, Red-Black, heap operations)
+### - [ ] Graph visualization mode (nodes and edges, not just grids)
+### - [ ] Stack and queue visualization with push/pop/enqueue/dequeue animations
+### - [ ] Linked list visualization (insert, delete, reverse, merge)
+### - [ ] Hash table visualization showing collision resolution strategies
+### - [ ] Matrix/2D array visualization for dynamic programming problems
+### - [ ] Add Floyd-Warshall (all-pairs shortest path) with matrix visualization
+### - [ ] Add topological sort with DAG visualization
+### - [ ] Add Tim Sort
+
+---
+
+## Phase 5 — Educational & Interactive Features
+
+### - [ ] Show real-time code highlighting synced with the current algorithm step
+### - [ ] Visualize auxiliary space usage (e.g., merge sort temp arrays shown separately)
+### - [ ] Add complexity graph overlay showing O(n), O(n log n), O(n^2) curves alongside actual performance
+### - [ ] Add tooltips explaining Big-O notation and complexity terms
+### - [ ] Add a tutorial/onboarding overlay for first-time users
+### - [ ] Let users write and plug in their own algorithm code (sandboxed JS editor)
+
+---
+
+## Phase 6 — Sharing & Export
+
+### - [ ] Export visualization as GIF or MP4 video
+### - [ ] Export visualization as a shareable URL with encoded state
+### - [ ] Save and load algorithm configurations/presets
+### - [ ] Import/export grid layouts as JSON or shareable URL
+### - [ ] Add a gallery of community-shared mazes and configurations
+
+---
+
+## Phase 7 — Performance & Architecture
+
+### - [ ] Move algorithm execution to a Web Worker to avoid blocking the UI
+### - [ ] Algorithm execution blocks the main thread on large inputs
+### - [ ] Virtualize rendering for very large arrays (500+ elements)
+### - [ ] Use WebGL/WebGPU for grid rendering at scale (100x200+ grids)
+### - [ ] Add PWA support for offline usage
+
+---
+
+## Phase 8 — Polish
+
+### - [ ] Add touch support for mobile grid interaction
+### - [ ] Allow users to draw custom weighted edges on the grid
+### - [ ] Add Vitest unit tests for all algorithm implementations
+### - [ ] Add E2E tests with Playwright for critical user flows
+### - [ ] Add ARIA labels to canvas elements and all interactive controls
+### - [ ] Add a colorblind-friendly palette option
+### - [ ] Add screen reader descriptions for algorithm state at each step
+### - [ ] Ensure full keyboard navigability throughout the app

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { GridVisualizer } from './components/visualizers/GridVisualizer';
 import { AlgorithmInfoCard } from './components/AlgorithmInfoCard';
 import { StatisticsDisplay } from './components/StatisticsDisplay';
 import { Card, CardContent } from './components/ui/card';
-import { ModeSelector } from './components/controls/ModeSelector';
 import { AlgorithmSelector } from './components/controls/AlgorithmSelector';
 import { ArraySizeControl } from './components/controls/ArraySizeControl';
 import { GenerateArrayButton } from './components/controls/GenerateArrayButton';
@@ -26,31 +25,35 @@ function App() {
   const algorithm = selectedAlgorithm ? getAlgorithm(selectedAlgorithm) : null;
 
   return (
-    <div className="min-h-screen bg-background p-8">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <Header />
+    <div className="h-screen overflow-hidden flex flex-col bg-background">
+      <Header mode={mode} onModeChange={controls.setMode} />
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-4">
+      <div className="flex-1 flex gap-4 overflow-hidden p-4 pt-0">
+        {/* Visualizer area */}
+        <div className="flex-1 min-w-0 flex flex-col gap-4">
+          <div className="flex-1 min-h-0">
             {mode === 'sorting' ? (
               <VisualizationArea currentStepData={currentStepData} algorithm={algorithm} />
             ) : (
-              <>
-                <GridVisualizer
-                  step={currentStepData}
-                  onCellClick={controls.setWall}
-                  onStartDrag={controls.setStart}
-                  onEndDrag={controls.setEnd}
-                />
+              <div className="flex flex-col h-full gap-4">
+                <div className="flex-1 min-h-0">
+                  <GridVisualizer
+                    step={currentStepData}
+                    onCellClick={controls.setWall}
+                    onStartDrag={controls.setStart}
+                    onEndDrag={controls.setEnd}
+                  />
+                </div>
                 {algorithm && <AlgorithmInfoCard algorithm={algorithm} />}
-              </>
+              </div>
             )}
           </div>
+        </div>
 
-          <Card>
+        {/* Sidebar */}
+        <div className="w-72 flex-shrink-0 overflow-y-auto">
+          <Card className="h-fit">
             <CardContent className="pt-6 space-y-6">
-              <ModeSelector mode={mode} onModeChange={controls.setMode} />
-
               <AlgorithmSelector
                 selectedAlgorithm={selectedAlgorithm}
                 onAlgorithmChange={controls.handleAlgorithmChange}
@@ -90,10 +93,10 @@ function App() {
               <SpeedControl speed={controls.speed} onSpeedChange={controls.setSpeed} />
 
               <StepCounter currentStep={currentStep} totalSteps={steps.length} />
+
+              {selectedAlgorithm && <StatisticsDisplay step={currentStepData} mode={mode} />}
             </CardContent>
           </Card>
-
-          {selectedAlgorithm && <StatisticsDisplay step={currentStepData} mode={mode} />}
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,16 @@
-export const Header = () => {
+import { ModeSelector } from './controls/ModeSelector';
+import type { AlgorithmMode } from '../types';
+
+interface HeaderProps {
+  mode: AlgorithmMode;
+  onModeChange: (mode: AlgorithmMode) => void;
+}
+
+export const Header = ({ mode, onModeChange }: HeaderProps) => {
   return (
-    <div className="text-center space-y-2">
-      <h1 className="text-4xl font-bold tracking-tight">CodeTrace</h1>
-      <p className="text-muted-foreground">Visualize algorithms in real-time</p>
+    <div className="flex justify-between items-center px-4 py-2">
+      <h1 className="text-2xl font-bold tracking-tight">CodeTrace</h1>
+      <ModeSelector mode={mode} onModeChange={onModeChange} />
     </div>
   );
 };

--- a/src/components/StatisticsDisplay.tsx
+++ b/src/components/StatisticsDisplay.tsx
@@ -1,4 +1,3 @@
-import { Card, CardContent } from './ui/card';
 import type { AlgorithmStep, AlgorithmMode } from '../types';
 
 interface StatisticsDisplayProps {
@@ -24,43 +23,41 @@ export const StatisticsDisplay = ({ step, mode }: StatisticsDisplayProps) => {
   };
 
   return (
-    <Card>
-      <CardContent className="pt-6">
-        <h3 className="text-sm font-medium mb-4">Statistics</h3>
-        <div className="space-y-3">
-          {mode === 'sorting' ? (
-            <>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Comparisons</span>
-                <span className="text-sm font-semibold">{stats.comparisons ?? 0}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Swaps</span>
-                <span className="text-sm font-semibold">{stats.swaps ?? 0}</span>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Nodes Visited</span>
-                <span className="text-sm font-semibold">{stats.nodesVisited ?? 0}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Path Length</span>
-                <span className="text-sm font-semibold">
-                  {stats.pathLength ? stats.pathLength : 'N/A'}
-                </span>
-              </div>
-            </>
-          )}
-          <div className="flex justify-between items-center border-t pt-3">
-            <span className="text-sm text-muted-foreground">Execution Time</span>
-            <span className="text-sm font-semibold">
-              {formatTime(stats.executionTime)}
-            </span>
-          </div>
+    <div>
+      <h3 className="text-sm font-medium mb-4">Statistics</h3>
+      <div className="space-y-3">
+        {mode === 'sorting' ? (
+          <>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Comparisons</span>
+              <span className="text-sm font-semibold">{stats.comparisons ?? 0}</span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Swaps</span>
+              <span className="text-sm font-semibold">{stats.swaps ?? 0}</span>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Nodes Visited</span>
+              <span className="text-sm font-semibold">{stats.nodesVisited ?? 0}</span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Path Length</span>
+              <span className="text-sm font-semibold">
+                {stats.pathLength ? stats.pathLength : 'N/A'}
+              </span>
+            </div>
+          </>
+        )}
+        <div className="flex justify-between items-center border-t pt-3">
+          <span className="text-sm text-muted-foreground">Execution Time</span>
+          <span className="text-sm font-semibold">
+            {formatTime(stats.executionTime)}
+          </span>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 };

--- a/src/components/VisualizationArea.tsx
+++ b/src/components/VisualizationArea.tsx
@@ -9,8 +9,10 @@ interface VisualizationAreaProps {
 
 export const VisualizationArea = ({ currentStepData, algorithm }: VisualizationAreaProps) => {
   return (
-    <div className="lg:col-span-2 space-y-4">
-      <SortingVisualizer step={currentStepData} width={800} height={400} />
+    <div className="flex flex-col h-full gap-4">
+      <div className="flex-1 min-h-0">
+        <SortingVisualizer step={currentStepData} />
+      </div>
       {algorithm && (
         <AlgorithmInfoCard algorithm={algorithm} currentMessage={currentStepData.message} />
       )}

--- a/src/components/controls/ModeSelector.tsx
+++ b/src/components/controls/ModeSelector.tsx
@@ -8,17 +8,14 @@ interface ModeSelectorProps {
 
 export const ModeSelector = ({ mode, onModeChange }: ModeSelectorProps) => {
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium">Visualization Mode</label>
-      <Select value={mode} onValueChange={onModeChange}>
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="sorting">Sorting Algorithms</SelectItem>
-          <SelectItem value="pathfinding">Pathfinding Algorithms</SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+    <Select value={mode} onValueChange={onModeChange}>
+      <SelectTrigger className="w-52">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="sorting">Sorting Algorithms</SelectItem>
+        <SelectItem value="pathfinding">Pathfinding Algorithms</SelectItem>
+      </SelectContent>
+    </Select>
   );
 };

--- a/src/components/visualizers/GridVisualizer.tsx
+++ b/src/components/visualizers/GridVisualizer.tsx
@@ -1,11 +1,10 @@
 import { useRef } from 'react';
 import type { AlgorithmStep } from '../../types';
 import { useGridRenderer } from '../../hooks/useGridRenderer';
+import { useContainerSize } from '../../hooks/useContainerSize';
 
 interface GridVisualizerProps {
   step: AlgorithmStep;
-  width?: number;
-  height?: number;
   onCellClick?: (row: number, col: number, isWall: boolean) => void;
   onStartDrag?: (row: number, col: number) => void;
   onEndDrag?: (row: number, col: number) => void;
@@ -13,32 +12,37 @@ interface GridVisualizerProps {
 
 export const GridVisualizer = ({
   step,
-  width = 1000,
-  height = 600,
   onCellClick,
   onStartDrag,
   onEndDrag,
 }: GridVisualizerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { width, height } = useContainerSize(containerRef);
+
+  const canvasWidth = Math.max(0, width - 32);
+  const canvasHeight = Math.max(0, height - 32);
 
   useGridRenderer({
     canvasRef,
     step,
-    width,
-    height,
+    width: canvasWidth,
+    height: canvasHeight,
     onCellClick,
     onStartDrag,
     onEndDrag,
   });
 
   return (
-    <div className="flex justify-center items-center bg-card rounded-lg border p-4">
-      <canvas
-        ref={canvasRef}
-        width={width}
-        height={height}
-        className="rounded cursor-pointer max-w-full max-h-[600px] w-auto h-auto"
-      />
+    <div ref={containerRef} className="w-full h-full bg-card rounded-lg border p-4">
+      {width > 0 && height > 0 && (
+        <canvas
+          ref={canvasRef}
+          width={canvasWidth}
+          height={canvasHeight}
+          className="rounded cursor-pointer"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/visualizers/SortingVisualizer.tsx
+++ b/src/components/visualizers/SortingVisualizer.tsx
@@ -1,26 +1,31 @@
 import { useRef } from 'react';
 import { useVisualizerRenderer } from '../../hooks/useVisualizerRenderer';
+import { useContainerSize } from '../../hooks/useContainerSize';
 import type { AlgorithmStep } from '../../types';
 
 interface SortingVisualizerProps {
   step: AlgorithmStep;
-  width?: number;
-  height?: number;
 }
 
-export const SortingVisualizer = ({ step, width = 800, height = 400 }: SortingVisualizerProps) => {
+export const SortingVisualizer = ({ step }: SortingVisualizerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { width, height } = useContainerSize(containerRef);
+  const canvasWidth = Math.max(0, width - 32);
+  const canvasHeight = Math.max(0, height - 32);
 
-  useVisualizerRenderer({ canvasRef, step, width, height });
+  useVisualizerRenderer({ canvasRef, step, width: canvasWidth, height: canvasHeight });
 
   return (
-    <div className="flex justify-center items-center bg-card rounded-lg border p-4">
-      <canvas
-        ref={canvasRef}
-        width={width}
-        height={height}
-        className="rounded"
-      />
+    <div ref={containerRef} className="w-full h-full bg-card rounded-lg border p-4">
+      {width > 0 && height > 0 && (
+        <canvas
+          ref={canvasRef}
+          width={width - 32}
+          height={height - 32}
+          className="rounded"
+        />
+      )}
     </div>
   );
 };

--- a/src/hooks/useContainerSize.ts
+++ b/src/hooks/useContainerSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, type RefObject } from 'react';
+
+interface ContainerSize {
+  width: number;
+  height: number;
+}
+
+export const useContainerSize = (ref: RefObject<HTMLElement | null>): ContainerSize => {
+  const [size, setSize] = useState<ContainerSize>({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        const { width, height } = entry.contentRect;
+        setSize({ width: Math.floor(width), height: Math.floor(height) });
+      }
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return size;
+};

--- a/src/hooks/useGridRenderer.ts
+++ b/src/hooks/useGridRenderer.ts
@@ -42,7 +42,7 @@ export const useGridRenderer = ({
     if (!canvas || !step.grid) return;
 
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx || width === 0 || height === 0) return;
 
     const { grid } = step;
     const cellWidth = width / grid.cols;

--- a/src/hooks/useVisualizerRenderer.ts
+++ b/src/hooks/useVisualizerRenderer.ts
@@ -20,7 +20,7 @@ export const useVisualizerRenderer = ({
     if (!canvas) return;
 
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx || width === 0 || height === 0) return;
 
     ctx.clearRect(0, 0, width, height);
 


### PR DESCRIPTION
Replace min-h-screen scrollable layout with h-screen flex layout. Move ModeSelector into header bar, integrate StatisticsDisplay into sidebar, and make canvas visualizers responsive via ResizeObserver instead of hardcoded dimensions.

Closes #2