### PR TITLE
fix: redesign layout to fit viewport without scrolling

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,56 @@
+# Issue Template (AI Agent Optimized)
+
+```markdown
+## Title
+
+### Branch
+`type/short-description` (e.g., `fix/layout-redesign`, `feat/dark-mode`, `fix/canvas-overflow`)
+
+### Why
+1-2 sentences. Why this matters to the user/product — not what the code currently looks like.
+
+### Files
+- `path/to/file.tsx` — short description of what changes here
+- `path/to/other.ts` — short description of what changes here
+
+### Tasks
+1. [ ] First task — do X in `file.tsx`. Be prescriptive, not suggestive
+2. [ ] Second task — do Y in `other.ts`
+3. [ ] Third task — do Z in `file.tsx` (depends on task 1)
+
+### Acceptance Criteria
+- [ ] `pnpm build` passes
+- [ ] `pnpm lint` passes
+- [ ] Concrete, verifiable condition (e.g., "no hardcoded widths remain in component")
+- [ ] [Visual] Description of what to visually confirm
+
+### Constraints
+- Do NOT touch X
+- Do NOT refactor Y
+- Agent's discretion on [specific thing you don't care about]
+```
+
+## Guidelines
+
+### Why this format works for AI agents
+- **File paths are the highest-ROI context.** Pointing to specific files saves the most tokens and prevents the agent from wandering the codebase.
+- **Ordered tasks with dependencies** prevent wrong-order bugs. Agents work sequentially — make the order explicit.
+- **Programmatic acceptance criteria** (`pnpm build` passes, "no X remains in file Y") let the agent self-verify. Visual checks are fine but shouldn't be the only verification.
+- **Constraints prevent scope creep.** Without them, agents tend to refactor adjacent code, add error handling, or install dependencies unprompted.
+
+### Branch naming convention
+Use `type/short-description` where type is one of: `feat`, `fix`, `refactor`, `chore`, `docs`. The agent should create this branch from `main`, do all work there, and PR back into `main`.
+
+### Before starting work
+The agent should always read `ISSUES.md` and check the current state of the files listed in the issue before making changes. Code may have changed since the issue was written — other issues may have been completed first, files may have been renamed, or logic may have moved. Never assume the issue description is a perfect snapshot of the current code.
+
+### When writing new issues
+Before writing an issue, the author (human or agent) must read the actual source files that will be affected. Issues should reference real line numbers, real class/function names, and real current behavior — not guesses. If a file has changed since the issue was drafted, update the issue before starting work.
+
+
+### Principles
+1. **Be prescriptive, not suggestive.** "Use `grid-cols-[1fr_300px]`" not "likely something like grid-cols". If you genuinely don't care, say "agent's discretion" explicitly.
+2. **Skip the background narrative.** The agent can read every file instantly. Don't describe what the code currently looks like — just say why the change matters.
+3. **One issue = one concern.** Agent adherence drops as instruction count rises. Split large specs into focused pieces.
+4. **Tailor constraints per issue.** Each constraint should answer: "What will the agent be tempted to do here that I don't want?" General project rules belong in `CLAUDE.md`, not in individual issues.
+5. **At least one programmatic check.** Every issue needs at least one acceptance criterion the agent can verify by running a command.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { VisualizationArea } from './components/VisualizationArea';
 import { StatisticsDisplay } from './components/StatisticsDisplay';
 import { Card, CardContent } from './components/ui/card';
-import { ModeSelector } from './components/controls/ModeSelector';
 import { AlgorithmSelector } from './components/controls/AlgorithmSelector';
 import { ArraySizeControl } from './components/controls/ArraySizeControl';
 import { GenerateArrayButton } from './components/controls/GenerateArrayButton';
@@ -29,27 +28,27 @@ function App() {
   const algorithm = selectedAlgorithm ? getAlgorithm(selectedAlgorithm) : null;
 
   return (
-    <div className="min-h-screen bg-background p-8">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <Header />
+    <div className="h-screen overflow-hidden flex flex-col bg-background">
+      <Header mode={mode} onModeChange={controls.setMode} />
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-4">
-            <ErrorBoundary>
-              <VisualizationArea
-                currentStepData={currentStepData}
-                algorithm={algorithm}
-                onCellClick={controls.setWall}
-                onStartDrag={controls.setStart}
-                onEndDrag={controls.setEnd}
-              />
-            </ErrorBoundary>
-          </div>
+      <div className="flex-1 flex gap-4 overflow-hidden p-4 pt-0">
+        {/* Visualizer area */}
+        <div className="flex-1 min-w-0">
+          <ErrorBoundary>
+            <VisualizationArea
+              currentStepData={currentStepData}
+              algorithm={algorithm}
+              onCellClick={controls.setWall}
+              onStartDrag={controls.setStart}
+              onEndDrag={controls.setEnd}
+            />
+          </ErrorBoundary>
+        </div>
 
-          <Card>
+        {/* Sidebar */}
+        <div className="w-72 flex-shrink-0 overflow-y-auto">
+          <Card className="h-fit">
             <CardContent className="pt-6 space-y-6">
-              <ModeSelector mode={mode} onModeChange={controls.setMode} />
-
               <AlgorithmSelector
                 selectedAlgorithm={selectedAlgorithm}
                 onAlgorithmChange={controls.handleAlgorithmChange}
@@ -89,10 +88,10 @@ function App() {
               <SpeedControl speed={controls.speed} onSpeedChange={controls.setSpeed} />
 
               <StepCounter currentStep={currentStep} totalSteps={steps.length} />
+
+              {selectedAlgorithm && <StatisticsDisplay step={currentStepData} />}
             </CardContent>
           </Card>
-
-          {selectedAlgorithm && <StatisticsDisplay step={currentStepData} />}
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,16 @@
-export const Header = () => {
+import { ModeSelector } from './controls/ModeSelector';
+import type { AlgorithmMode } from '../types';
+
+interface HeaderProps {
+  mode: AlgorithmMode;
+  onModeChange: (mode: AlgorithmMode) => void;
+}
+
+export const Header = ({ mode, onModeChange }: HeaderProps) => {
   return (
-    <div className="text-center space-y-2">
-      <h1 className="text-4xl font-bold tracking-tight">CodeTrace</h1>
-      <p className="text-muted-foreground">Visualize algorithms in real-time</p>
+    <div className="flex justify-between items-center px-4 py-2">
+      <h1 className="text-2xl font-bold tracking-tight">CodeTrace</h1>
+      <ModeSelector mode={mode} onModeChange={onModeChange} />
     </div>
   );
 };

--- a/src/components/StatisticsDisplay.tsx
+++ b/src/components/StatisticsDisplay.tsx
@@ -1,4 +1,3 @@
-import { Card, CardContent } from './ui/card';
 import type { AlgorithmStep } from '../types';
 
 interface StatisticsDisplayProps {
@@ -23,43 +22,41 @@ export const StatisticsDisplay = ({ step }: StatisticsDisplayProps) => {
   };
 
   return (
-    <Card>
-      <CardContent className="pt-6">
-        <h3 className="text-sm font-medium mb-4">Statistics</h3>
-        <div className="space-y-3">
-          {step.type === 'sorting' ? (
-            <>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Comparisons</span>
-                <span className="text-sm font-semibold">{stats.comparisons ?? 0}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Swaps</span>
-                <span className="text-sm font-semibold">{stats.swaps ?? 0}</span>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Nodes Visited</span>
-                <span className="text-sm font-semibold">{stats.nodesVisited ?? 0}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-muted-foreground">Path Length</span>
-                <span className="text-sm font-semibold">
-                  {stats.pathLength ? stats.pathLength : 'N/A'}
-                </span>
-              </div>
-            </>
-          )}
-          <div className="flex justify-between items-center border-t pt-3">
-            <span className="text-sm text-muted-foreground">Execution Time</span>
-            <span className="text-sm font-semibold">
-              {formatTime(stats.executionTime)}
-            </span>
-          </div>
+    <div>
+      <h3 className="text-sm font-medium mb-4">Statistics</h3>
+      <div className="space-y-3">
+        {step.type === 'sorting' ? (
+          <>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Comparisons</span>
+              <span className="text-sm font-semibold">{stats.comparisons ?? 0}</span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Swaps</span>
+              <span className="text-sm font-semibold">{stats.swaps ?? 0}</span>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Nodes Visited</span>
+              <span className="text-sm font-semibold">{stats.nodesVisited ?? 0}</span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Path Length</span>
+              <span className="text-sm font-semibold">
+                {stats.pathLength ? stats.pathLength : 'N/A'}
+              </span>
+            </div>
+          </>
+        )}
+        <div className="flex justify-between items-center border-t pt-3">
+          <span className="text-sm text-muted-foreground">Execution Time</span>
+          <span className="text-sm font-semibold">
+            {formatTime(stats.executionTime)}
+          </span>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 };

--- a/src/components/VisualizationArea.tsx
+++ b/src/components/VisualizationArea.tsx
@@ -19,17 +19,19 @@ export const VisualizationArea = ({
   onEndDrag,
 }: VisualizationAreaProps) => {
   return (
-    <div className="space-y-4">
-      {currentStepData.type === 'sorting' ? (
-        <SortingVisualizer step={currentStepData} width={800} height={400} />
-      ) : (
-        <GridVisualizer
-          step={currentStepData}
-          onCellClick={onCellClick}
-          onStartDrag={onStartDrag}
-          onEndDrag={onEndDrag}
-        />
-      )}
+    <div className="flex flex-col h-full gap-4">
+      <div className="flex-1 min-h-0">
+        {currentStepData.type === 'sorting' ? (
+          <SortingVisualizer step={currentStepData} />
+        ) : (
+          <GridVisualizer
+            step={currentStepData}
+            onCellClick={onCellClick}
+            onStartDrag={onStartDrag}
+            onEndDrag={onEndDrag}
+          />
+        )}
+      </div>
       {algorithm && (
         <AlgorithmInfoCard algorithm={algorithm} currentMessage={currentStepData.message} />
       )}

--- a/src/components/controls/ModeSelector.tsx
+++ b/src/components/controls/ModeSelector.tsx
@@ -8,17 +8,14 @@ interface ModeSelectorProps {
 
 export const ModeSelector = ({ mode, onModeChange }: ModeSelectorProps) => {
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium">Visualization Mode</label>
-      <Select value={mode} onValueChange={onModeChange}>
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="sorting">Sorting Algorithms</SelectItem>
-          <SelectItem value="pathfinding">Pathfinding Algorithms</SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+    <Select value={mode} onValueChange={onModeChange}>
+      <SelectTrigger className="w-52">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="sorting">Sorting Algorithms</SelectItem>
+        <SelectItem value="pathfinding">Pathfinding Algorithms</SelectItem>
+      </SelectContent>
+    </Select>
   );
 };

--- a/src/components/visualizers/GridVisualizer.tsx
+++ b/src/components/visualizers/GridVisualizer.tsx
@@ -1,11 +1,10 @@
 import { useRef } from 'react';
 import type { PathfindingStep } from '../../types';
 import { useGridRenderer } from '../../hooks/useGridRenderer';
+import { useContainerSize } from '../../hooks/useContainerSize';
 
 interface GridVisualizerProps {
   step: PathfindingStep;
-  width?: number;
-  height?: number;
   onCellClick?: (row: number, col: number, isWall: boolean) => void;
   onStartDrag?: (row: number, col: number) => void;
   onEndDrag?: (row: number, col: number) => void;
@@ -13,32 +12,36 @@ interface GridVisualizerProps {
 
 export const GridVisualizer = ({
   step,
-  width = 1000,
-  height = 600,
   onCellClick,
   onStartDrag,
   onEndDrag,
 }: GridVisualizerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { width, height } = useContainerSize(containerRef);
+  const canvasWidth = Math.max(0, width - 32);
+  const canvasHeight = Math.max(0, height - 32);
 
   useGridRenderer({
     canvasRef,
     step,
-    width,
-    height,
+    width: canvasWidth,
+    height: canvasHeight,
     onCellClick,
     onStartDrag,
     onEndDrag,
   });
 
   return (
-    <div className="flex justify-center items-center bg-card rounded-lg border p-4">
-      <canvas
-        ref={canvasRef}
-        width={width}
-        height={height}
-        className="rounded cursor-pointer max-w-full max-h-[600px] w-auto h-auto"
-      />
+    <div ref={containerRef} className="w-full h-full bg-card rounded-lg border p-4">
+      {canvasWidth > 0 && canvasHeight > 0 && (
+        <canvas
+          ref={canvasRef}
+          width={canvasWidth}
+          height={canvasHeight}
+          className="rounded cursor-pointer"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/visualizers/SortingVisualizer.tsx
+++ b/src/components/visualizers/SortingVisualizer.tsx
@@ -1,26 +1,31 @@
 import { useRef } from 'react';
 import { useVisualizerRenderer } from '../../hooks/useVisualizerRenderer';
+import { useContainerSize } from '../../hooks/useContainerSize';
 import type { SortingStep } from '../../types';
 
 interface SortingVisualizerProps {
   step: SortingStep;
-  width?: number;
-  height?: number;
 }
 
-export const SortingVisualizer = ({ step, width = 800, height = 400 }: SortingVisualizerProps) => {
+export const SortingVisualizer = ({ step }: SortingVisualizerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { width, height } = useContainerSize(containerRef);
+  const canvasWidth = Math.max(0, width - 32);
+  const canvasHeight = Math.max(0, height - 32);
 
-  useVisualizerRenderer({ canvasRef, step, width, height });
+  useVisualizerRenderer({ canvasRef, step, width: canvasWidth, height: canvasHeight });
 
   return (
-    <div className="flex justify-center items-center bg-card rounded-lg border p-4">
-      <canvas
-        ref={canvasRef}
-        width={width}
-        height={height}
-        className="rounded"
-      />
+    <div ref={containerRef} className="w-full h-full bg-card rounded-lg border p-4">
+      {canvasWidth > 0 && canvasHeight > 0 && (
+        <canvas
+          ref={canvasRef}
+          width={canvasWidth}
+          height={canvasHeight}
+          className="rounded"
+        />
+      )}
     </div>
   );
 };

--- a/src/hooks/useContainerSize.ts
+++ b/src/hooks/useContainerSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, type RefObject } from 'react';
+
+interface ContainerSize {
+  width: number;
+  height: number;
+}
+
+export const useContainerSize = (ref: RefObject<HTMLElement | null>): ContainerSize => {
+  const [size, setSize] = useState<ContainerSize>({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        const { width, height } = entry.contentRect;
+        setSize({ width: Math.floor(width), height: Math.floor(height) });
+      }
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return size;
+};

--- a/src/hooks/useGridRenderer.ts
+++ b/src/hooks/useGridRenderer.ts
@@ -42,7 +42,7 @@ export const useGridRenderer = ({
     if (!canvas) return;
 
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx || width === 0 || height === 0) return;
 
     const { grid } = step;
     const cellWidth = width / grid.cols;

--- a/src/hooks/useVisualizerRenderer.ts
+++ b/src/hooks/useVisualizerRenderer.ts
@@ -20,7 +20,7 @@ export const useVisualizerRenderer = ({
     if (!canvas) return;
 
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx || width === 0 || height === 0) return;
 
     ctx.clearRect(0, 0, width, height);
 


### PR DESCRIPTION
Replace min-h-screen scrollable layout with h-screen flex layout. Move ModeSelector into header bar, integrate StatisticsDisplay into sidebar, and make canvas visualizers responsive via ResizeObserver instead of hardcoded dimensions.

Closes #2