### PR TITLE
fix: make canvas responsive and debounce pathfinding grid sliders

### DIFF
--- a/src/components/visualizers/GridVisualizer.tsx
+++ b/src/components/visualizers/GridVisualizer.tsx
@@ -19,8 +19,8 @@ export const GridVisualizer = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { width, height } = useContainerSize(containerRef);
-  const canvasWidth = Math.max(0, width - 32);
-  const canvasHeight = Math.max(0, height - 32);
+  const canvasWidth = width;
+  const canvasHeight = height;
 
   useGridRenderer({
     canvasRef,

--- a/src/components/visualizers/SortingVisualizer.tsx
+++ b/src/components/visualizers/SortingVisualizer.tsx
@@ -11,8 +11,8 @@ export const SortingVisualizer = ({ step }: SortingVisualizerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { width, height } = useContainerSize(containerRef);
-  const canvasWidth = Math.max(0, width - 32);
-  const canvasHeight = Math.max(0, height - 32);
+  const canvasWidth = width;
+  const canvasHeight = height;
 
   useVisualizerRenderer({ canvasRef, step, width: canvasWidth, height: canvasHeight });
 

--- a/src/hooks/useVisualizationControls.ts
+++ b/src/hooks/useVisualizationControls.ts
@@ -63,15 +63,37 @@ export const useVisualizationControls = () => {
     }
   }, [playback, gridManagement, selectedAlgorithm, pathfindingExecution]);
 
+  const [displayRows, setDisplayRows] = useState(gridManagement.rows);
+  const [displayCols, setDisplayCols] = useState(gridManagement.cols);
+  const gridDebounceRef = useRef<number | null>(null);
+
   const handleRowsChange = useCallback((newRows: number) => {
     playback.reset();
-    gridManagement.setRows(newRows);
-  }, [playback, gridManagement]);
+    setDisplayRows(newRows);
+    if (gridDebounceRef.current !== null) {
+      clearTimeout(gridDebounceRef.current);
+    }
+    gridDebounceRef.current = window.setTimeout(() => {
+      gridManagement.setRows(newRows);
+      if (selectedAlgorithm) {
+        pathfindingExecution.executeAlgorithm(selectedAlgorithm);
+      }
+    }, 300);
+  }, [playback, gridManagement, selectedAlgorithm, pathfindingExecution]);
 
   const handleColsChange = useCallback((newCols: number) => {
     playback.reset();
-    gridManagement.setCols(newCols);
-  }, [playback, gridManagement]);
+    setDisplayCols(newCols);
+    if (gridDebounceRef.current !== null) {
+      clearTimeout(gridDebounceRef.current);
+    }
+    gridDebounceRef.current = window.setTimeout(() => {
+      gridManagement.setCols(newCols);
+      if (selectedAlgorithm) {
+        pathfindingExecution.executeAlgorithm(selectedAlgorithm);
+      }
+    }, 300);
+  }, [playback, gridManagement, selectedAlgorithm, pathfindingExecution]);
 
   const sizeDebounceRef = useRef<number | null>(null);
   const handleSizeChange = useCallback((newSize: number) => {
@@ -94,8 +116,8 @@ export const useVisualizationControls = () => {
     array: arrayManagement.array,
     size: arrayManagement.size,
     gridData: gridManagement.gridData,
-    rows: gridManagement.rows,
-    cols: gridManagement.cols,
+    rows: displayRows,
+    cols: displayCols,
     steps,
     currentStep: playback.currentStep,
     isPlaying: playback.isPlaying,


### PR DESCRIPTION
Remove redundant padding subtraction in SortingVisualizer and GridVisualizer — useContainerSize's contentRect already excludes padding, so the -32 was double-counting it. Add debounce to pathfinding rows/cols sliders to match the existing sorting slider pattern, deferring expensive grid rebuilds by 300ms.

Closes #3