### PR TITLE
fix: add vertical scroll to code panel and min height to canvas

### DIFF
--- a/src/components/AlgorithmInfoCard.tsx
+++ b/src/components/AlgorithmInfoCard.tsx
@@ -36,7 +36,7 @@ export const AlgorithmInfoCard = ({ algorithm, currentMessage }: AlgorithmInfoCa
 
         {showCode && (
           <div className="mt-4">
-            <div className="bg-muted p-4 rounded-md overflow-x-auto">
+            <div className="bg-muted p-3 rounded-md max-h-[30vh] overflow-y-auto overflow-x-auto">
               <pre className="text-sm">
                 <code>{algorithm.code}</code>
               </pre>

--- a/src/components/VisualizationArea.tsx
+++ b/src/components/VisualizationArea.tsx
@@ -20,7 +20,7 @@ export const VisualizationArea = ({
 }: VisualizationAreaProps) => {
   return (
     <div className="flex flex-col h-full gap-4">
-      <div className="flex-1 min-h-0">
+      <div className="flex-1 min-h-[300px]">
         {currentStepData.type === 'sorting' ? (
           <SortingVisualizer step={currentStepData} />
         ) : (


### PR DESCRIPTION
Add max-h-[30vh] with overflow-y-auto to the algorithm code display so longer implementations scroll instead of overflowing. Set min-h-[300px] on the canvas container to prevent it from shrinking to nothing on small viewports.
Closes #4