### PR TITLE
Add audio feedback with completion sweep for sorting visualizations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Header } from './components/Header';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { VisualizationArea } from './components/VisualizationArea';
@@ -14,11 +14,24 @@ import { ClearGridButton } from './components/controls/ClearGridButton';
 import { PlaybackControls } from './components/controls/PlaybackControls';
 import { SpeedControl } from './components/controls/SpeedControl';
 import { StepCounter } from './components/controls/StepCounter';
+import { SoundToggle } from './components/controls/SoundToggle';
 import { useVisualizationControls } from './hooks/useVisualizationControls';
 import { getAlgorithm } from './algorithms';
 
 
 function App() {
+  const [soundEnabled, setSoundEnabled] = useState(
+    () => localStorage.getItem('codetrace-sound') === 'true'
+  );
+
+  const toggleSound = useCallback(() => {
+    setSoundEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem('codetrace-sound', String(next));
+      return next;
+    });
+  }, []);
+
   const controls = useVisualizationControls();
   const { mode, steps, currentStep, selectedAlgorithm, array, gridData } = controls;
 
@@ -72,6 +85,7 @@ function App() {
             <VisualizationArea
               currentStepData={currentStepData}
               algorithm={algorithm}
+              soundEnabled={mode === 'sorting' && soundEnabled}
               onCellClick={controls.setWall}
               onStartDrag={controls.setStart}
               onEndDrag={controls.setEnd}
@@ -120,6 +134,10 @@ function App() {
               />
 
               <SpeedControl speed={controls.speed} onSpeedChange={controls.setSpeed} />
+
+              {mode === 'sorting' && (
+                <SoundToggle soundEnabled={soundEnabled} onToggle={toggleSound} />
+              )}
 
               <StepCounter currentStep={currentStep} totalSteps={steps.length} />
 

--- a/src/components/VisualizationArea.tsx
+++ b/src/components/VisualizationArea.tsx
@@ -6,6 +6,7 @@ import type { AlgorithmStep, Algorithm } from '../types';
 interface VisualizationAreaProps {
   currentStepData: AlgorithmStep;
   algorithm: Algorithm | null | undefined;
+  soundEnabled?: boolean;
   onCellClick?: (row: number, col: number, isWall: boolean) => void;
   onStartDrag?: (row: number, col: number) => void;
   onEndDrag?: (row: number, col: number) => void;
@@ -14,6 +15,7 @@ interface VisualizationAreaProps {
 export const VisualizationArea = ({
   currentStepData,
   algorithm,
+  soundEnabled,
   onCellClick,
   onStartDrag,
   onEndDrag,
@@ -22,7 +24,7 @@ export const VisualizationArea = ({
     <div className="flex flex-col h-full gap-4">
       <div className="flex-1 min-h-[300px]">
         {currentStepData.type === 'sorting' ? (
-          <SortingVisualizer step={currentStepData} />
+          <SortingVisualizer step={currentStepData} soundEnabled={soundEnabled} />
         ) : (
           <GridVisualizer
             step={currentStepData}

--- a/src/components/controls/SoundToggle.tsx
+++ b/src/components/controls/SoundToggle.tsx
@@ -1,0 +1,25 @@
+import { Volume2, VolumeX } from 'lucide-react';
+
+interface SoundToggleProps {
+  soundEnabled: boolean;
+  onToggle: () => void;
+}
+
+export const SoundToggle = ({ soundEnabled, onToggle }: SoundToggleProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-medium">Sound</span>
+      <button
+        onClick={onToggle}
+        className="p-2 rounded-md hover:bg-accent transition-colors"
+        aria-label={soundEnabled ? 'Mute sound' : 'Unmute sound'}
+      >
+        {soundEnabled ? (
+          <Volume2 className="h-4 w-4" />
+        ) : (
+          <VolumeX className="h-4 w-4 text-muted-foreground" />
+        )}
+      </button>
+    </div>
+  );
+};

--- a/src/components/visualizers/SortingVisualizer.tsx
+++ b/src/components/visualizers/SortingVisualizer.tsx
@@ -5,16 +5,17 @@ import type { SortingStep } from '../../types';
 
 interface SortingVisualizerProps {
   step: SortingStep;
+  soundEnabled?: boolean;
 }
 
-export const SortingVisualizer = ({ step }: SortingVisualizerProps) => {
+export const SortingVisualizer = ({ step, soundEnabled }: SortingVisualizerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { width, height } = useContainerSize(containerRef);
   const canvasWidth = width;
   const canvasHeight = height;
 
-  useVisualizerRenderer({ canvasRef, step, width: canvasWidth, height: canvasHeight });
+  useVisualizerRenderer({ canvasRef, step, width: canvasWidth, height: canvasHeight, soundEnabled });
 
   return (
     <div ref={containerRef} className="w-full h-full bg-card rounded-lg border p-4">

--- a/src/hooks/useVisualizerRenderer.ts
+++ b/src/hooks/useVisualizerRenderer.ts
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
-import { getBarColor } from '../utils/colorUtils';
+import { useEffect, useRef } from 'react';
+import { getBarColor, VISUALIZER_COLORS } from '../utils/colorUtils';
+import { playTone } from '../utils/audioUtils';
 import type { SortingStep } from '../types';
 import { useTheme } from './useTheme';
 
@@ -8,6 +9,38 @@ interface UseVisualizerRendererProps {
   step: SortingStep;
   width: number;
   height: number;
+  soundEnabled?: boolean;
+}
+
+function drawBars(
+  ctx: CanvasRenderingContext2D,
+  array: number[],
+  width: number,
+  height: number,
+  getColor: (index: number) => string
+) {
+  ctx.clearRect(0, 0, width, height);
+
+  const barWidth = width / array.length;
+  const maxValue = Math.max(...array);
+  const padding = 20;
+
+  const foreground = getComputedStyle(document.documentElement).getPropertyValue('--foreground').trim();
+  const textColor = foreground ? `hsl(${foreground})` : '#ffffff';
+
+  array.forEach((value, index) => {
+    const barHeight = (value / maxValue) * (height - padding * 2);
+    const x = index * barWidth;
+    const y = height - barHeight - padding;
+
+    ctx.fillStyle = getColor(index);
+    ctx.fillRect(x + 2, y, barWidth - 4, barHeight);
+
+    ctx.fillStyle = textColor;
+    ctx.font = '12px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText(value.toString(), x + barWidth / 2, y - 5);
+  });
 }
 
 export const useVisualizerRenderer = ({
@@ -15,37 +48,85 @@ export const useVisualizerRenderer = ({
   step,
   width,
   height,
+  soundEnabled,
 }: UseVisualizerRendererProps) => {
   const dark = useTheme();
+  const prevStepRef = useRef<SortingStep | null>(null);
+  const sweepTimersRef = useRef<number[]>([]);
+
+  // Clean up any running sweep
+  const cancelSweep = () => {
+    for (const id of sweepTimersRef.current) {
+      clearTimeout(id);
+    }
+    sweepTimersRef.current = [];
+  };
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
     const ctx = canvas.getContext('2d');
     if (!ctx || width === 0 || height === 0) return;
 
-    ctx.clearRect(0, 0, width, height);
-
     const { array, comparing = [], swapping = [], sorted = [] } = step;
-    const barWidth = width / array.length;
-    const maxValue = Math.max(...array);
-    const padding = 20;
+    const isComplete = sorted.length === array.length && comparing.length === 0 && swapping.length === 0;
+    const isNewStep = step !== prevStepRef.current;
 
-    array.forEach((value, index) => {
-      const barHeight = (value / maxValue) * (height - padding * 2);
-      const x = index * barWidth;
-      const y = height - barHeight - padding;
+    // Play tones for normal compare/swap steps
+    if (soundEnabled && isNewStep && !isComplete) {
+      const maxValue = Math.max(...array);
+      const indices = swapping.length > 0 ? swapping : comparing;
+      for (const idx of indices) {
+        playTone(array[idx], maxValue);
+      }
+    }
 
-      const color = getBarColor(index, comparing, swapping, sorted);
+    // If this is a new completion step with sound, run the sweep animation
+    if (soundEnabled && isNewStep && isComplete) {
+      cancelSweep();
 
-      ctx.fillStyle = color;
-      ctx.fillRect(x + 2, y, barWidth - 4, barHeight);
+      const maxValue = Math.max(...array);
+      let sweepIndex = 0;
 
-      const foreground = getComputedStyle(document.documentElement).getPropertyValue('--foreground').trim();
-      ctx.fillStyle = foreground ? `hsl(${foreground})` : '#ffffff';
-      ctx.font = '12px monospace';
-      ctx.textAlign = 'center';
-      ctx.fillText(value.toString(), x + barWidth / 2, y - 5);
-    });
-  }, [canvasRef, step, width, height, dark]);
+      // Draw initial state with default (blue) bars
+      drawBars(ctx, array, width, height, () => VISUALIZER_COLORS.default);
+
+      const sweepDelay = 30;
+      const timers: number[] = [];
+
+      for (let i = 0; i < array.length; i++) {
+        const id = window.setTimeout(() => {
+          sweepIndex = i;
+          playTone(array[i], maxValue, 30);
+
+          drawBars(ctx, array, width, height, (index) => {
+            if (index < sweepIndex) return VISUALIZER_COLORS.sorted;
+            if (index === sweepIndex) return VISUALIZER_COLORS.comparing;
+            return VISUALIZER_COLORS.default;
+          });
+        }, i * sweepDelay);
+        timers.push(id);
+      }
+
+      // Final frame: all green
+      const finalId = window.setTimeout(() => {
+        drawBars(ctx, array, width, height, () => VISUALIZER_COLORS.sorted);
+        sweepTimersRef.current = [];
+      }, array.length * sweepDelay);
+      timers.push(finalId);
+
+      sweepTimersRef.current = timers;
+    } else if (!isComplete || !soundEnabled) {
+      // Normal rendering (non-completion steps, or sound disabled)
+      cancelSweep();
+      drawBars(ctx, array, width, height, (index) =>
+        getBarColor(index, comparing, swapping, sorted)
+      );
+    }
+
+    prevStepRef.current = step;
+  }, [canvasRef, step, width, height, dark, soundEnabled]);
+
+  // Cleanup on unmount
+  useEffect(() => cancelSweep, []);
 };

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -1,0 +1,39 @@
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+export function playTone(
+  value: number,
+  maxValue: number,
+  duration: number = 50
+): void {
+  const ctx = getAudioContext();
+
+  if (ctx.state === 'suspended') {
+    ctx.resume();
+  }
+
+  const frequency = 200 + (value / maxValue) * 600;
+  const durationSec = duration / 1000;
+
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(frequency, ctx.currentTime);
+
+  gain.gain.setValueAtTime(0, ctx.currentTime);
+  gain.gain.linearRampToValueAtTime(0.15, ctx.currentTime + durationSec * 0.1);
+  gain.gain.linearRampToValueAtTime(0, ctx.currentTime + durationSec);
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+
+  oscillator.start(ctx.currentTime);
+  oscillator.stop(ctx.currentTime + durationSec);
+}


### PR DESCRIPTION
Map array element values to tone frequencies (200-800Hz) during compare/swap operations. On completion, play a left-to-right visual and audio sweep before bars turn green. Sound defaults to muted and persists preference to localStorage.

Closes #21