### PR TITLE
Add side-by-side algorithm comparison mode for sorting visualizations

### DIFF
--- a/src/components/ComparisonView.tsx
+++ b/src/components/ComparisonView.tsx
@@ -1,0 +1,44 @@
+import { SortingVisualizer } from './visualizers/SortingVisualizer';
+import { getAlgorithm } from '../algorithms';
+import type { SortingStep } from '../types';
+
+interface ComparisonViewProps {
+  leftAlgorithm: string | null;
+  rightAlgorithm: string | null;
+  leftStepData: SortingStep;
+  rightStepData: SortingStep;
+  soundEnabled: boolean;
+}
+
+export const ComparisonView = ({
+  leftAlgorithm,
+  rightAlgorithm,
+  leftStepData,
+  rightStepData,
+  soundEnabled,
+}: ComparisonViewProps) => {
+  const leftAlgo = leftAlgorithm ? getAlgorithm(leftAlgorithm) : null;
+  const rightAlgo = rightAlgorithm ? getAlgorithm(rightAlgorithm) : null;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 h-full">
+      <div className="flex flex-col min-h-0">
+        <div className="text-sm font-medium mb-2 text-center">
+          {leftAlgo?.name ?? 'Select Left Algorithm'}
+        </div>
+        <div className="flex-1 min-h-0">
+          <SortingVisualizer step={leftStepData} soundEnabled={soundEnabled} />
+        </div>
+      </div>
+
+      <div className="flex flex-col min-h-0">
+        <div className="text-sm font-medium mb-2 text-center">
+          {rightAlgo?.name ?? 'Select Right Algorithm'}
+        </div>
+        <div className="flex-1 min-h-0">
+          <SortingVisualizer step={rightStepData} soundEnabled={soundEnabled} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,9 +14,11 @@ function getInitialDark(): boolean {
 interface HeaderProps {
   mode: AlgorithmMode;
   onModeChange: (mode: AlgorithmMode) => void;
+  comparisonMode?: boolean;
+  onComparisonModeChange?: (enabled: boolean) => void;
 }
 
-export const Header = ({ mode, onModeChange }: HeaderProps) => {
+export const Header = ({ mode, onModeChange, comparisonMode, onComparisonModeChange }: HeaderProps) => {
   const [dark, setDark] = useState(getInitialDark);
 
   useEffect(() => {
@@ -28,6 +30,18 @@ export const Header = ({ mode, onModeChange }: HeaderProps) => {
     <div className="flex justify-between items-center px-4 py-2">
       <h1 className="text-2xl font-bold tracking-tight">CodeTrace</h1>
       <div className="flex items-center gap-4">
+        {mode === 'sorting' && onComparisonModeChange && (
+          <button
+            onClick={() => onComparisonModeChange(!comparisonMode)}
+            className={`inline-flex items-center justify-center rounded-md border border-input p-2 hover:bg-accent hover:text-accent-foreground ${
+              comparisonMode ? 'bg-accent text-accent-foreground' : 'bg-background'
+            }`}
+            aria-label="Toggle comparison mode"
+            title="Compare two algorithms"
+          >
+            <span className="text-xs font-bold">VS</span>
+          </button>
+        )}
         <button
           onClick={() => setDark((d) => !d)}
           className="inline-flex items-center justify-center rounded-md border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground"

--- a/src/components/controls/ComparisonControls.tsx
+++ b/src/components/controls/ComparisonControls.tsx
@@ -1,0 +1,141 @@
+import { AlgorithmSelector } from './AlgorithmSelector';
+import { ArraySizeControl } from './ArraySizeControl';
+import { GenerateArrayButton } from './GenerateArrayButton';
+import { ArrayInput } from './ArrayInput';
+import { PlaybackControls } from './PlaybackControls';
+import { SpeedControl } from './SpeedControl';
+import { SoundToggle } from './SoundToggle';
+import { StatisticsDisplay } from '../StatisticsDisplay';
+import type { ArrayPreset } from '../../hooks/useArrayManagement';
+import type { SortingStep } from '../../types';
+
+interface ComparisonControlsProps {
+  leftAlgorithm: string | null;
+  rightAlgorithm: string | null;
+  onLeftAlgorithmChange: (algorithm: string) => void;
+  onRightAlgorithmChange: (algorithm: string) => void;
+  size: number;
+  onSizeChange: (size: number) => void;
+  onGenerate: (preset?: ArrayPreset) => void;
+  onSetCustomArray: (arr: number[]) => void;
+  isPlaying: boolean;
+  currentStep: number;
+  totalSteps: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onReset: () => void;
+  onStepForward: () => void;
+  onStepBackward: () => void;
+  speed: number;
+  onSpeedChange: (speed: number) => void;
+  soundEnabled: boolean;
+  onToggleSound: () => void;
+  leftStepData: SortingStep | null;
+  rightStepData: SortingStep | null;
+  leftAlgorithmName: string | undefined;
+  rightAlgorithmName: string | undefined;
+  leftTotalSteps: number;
+  rightTotalSteps: number;
+}
+
+export const ComparisonControls = ({
+  leftAlgorithm,
+  rightAlgorithm,
+  onLeftAlgorithmChange,
+  onRightAlgorithmChange,
+  size,
+  onSizeChange,
+  onGenerate,
+  onSetCustomArray,
+  isPlaying,
+  currentStep,
+  totalSteps,
+  onPlay,
+  onPause,
+  onReset,
+  onStepForward,
+  onStepBackward,
+  speed,
+  onSpeedChange,
+  soundEnabled,
+  onToggleSound,
+  leftStepData,
+  rightStepData,
+  leftAlgorithmName,
+  rightAlgorithmName,
+  leftTotalSteps,
+  rightTotalSteps,
+}: ComparisonControlsProps) => {
+  const canPlay = leftAlgorithm && rightAlgorithm;
+
+  return (
+    <>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Left Algorithm</label>
+        <AlgorithmSelector
+          selectedAlgorithm={leftAlgorithm}
+          onAlgorithmChange={onLeftAlgorithmChange}
+          mode="sorting"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Right Algorithm</label>
+        <AlgorithmSelector
+          selectedAlgorithm={rightAlgorithm}
+          onAlgorithmChange={onRightAlgorithmChange}
+          mode="sorting"
+        />
+      </div>
+
+      <ArraySizeControl size={size} onSizeChange={onSizeChange} />
+      <ArrayInput onSetCustomArray={onSetCustomArray} />
+      <GenerateArrayButton onGenerate={onGenerate} />
+
+      <PlaybackControls
+        isPlaying={isPlaying}
+        currentStep={currentStep}
+        totalSteps={totalSteps}
+        selectedAlgorithm={canPlay ? 'comparison' : null}
+        onPlay={onPlay}
+        onPause={onPause}
+        onReset={onReset}
+        onStepForward={onStepForward}
+        onStepBackward={onStepBackward}
+      />
+
+      <SpeedControl speed={speed} onSpeedChange={onSpeedChange} />
+      <SoundToggle soundEnabled={soundEnabled} onToggle={onToggleSound} />
+
+      {canPlay && (
+        <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground text-center">
+          <span>{leftAlgorithmName}: Step {Math.min(currentStep + 1, leftTotalSteps)} of {leftTotalSteps}</span>
+          <span>{rightAlgorithmName}: Step {Math.min(currentStep + 1, rightTotalSteps)} of {rightTotalSteps}</span>
+        </div>
+      )}
+
+      {leftStepData && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">{leftAlgorithmName ?? 'Left'}</p>
+          <StatisticsDisplay step={leftStepData} />
+        </div>
+      )}
+
+      {rightStepData && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">{rightAlgorithmName ?? 'Right'}</p>
+          <StatisticsDisplay step={rightStepData} />
+        </div>
+      )}
+
+      <div className="text-xs text-muted-foreground space-y-1">
+        <p className="font-medium">Keyboard Shortcuts</p>
+        <div className="grid grid-cols-2 gap-x-2 gap-y-0.5">
+          <kbd className="font-mono">Space</kbd><span>Play / Pause</span>
+          <kbd className="font-mono">◀ ▶</kbd><span>Step</span>
+          <kbd className="font-mono">R</kbd><span>Reset</span>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/hooks/useComparisonMode.ts
+++ b/src/hooks/useComparisonMode.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useArrayManagement, type ArrayPreset } from './useArrayManagement';
+import { usePlaybackAnimation } from './usePlaybackAnimation';
+import { algorithms } from '../algorithms';
+import type { SortingStep } from '../types';
+
+export const useComparisonMode = () => {
+  const { array, size, setSize, generateArray, setCustomArray } = useArrayManagement();
+
+  const [leftAlgorithm, setLeftAlgorithm] = useState<string | null>(null);
+  const [rightAlgorithm, setRightAlgorithm] = useState<string | null>(null);
+  const [leftSteps, setLeftSteps] = useState<SortingStep[]>([]);
+  const [rightSteps, setRightSteps] = useState<SortingStep[]>([]);
+  const [speed, setSpeed] = useState(200);
+  const [soundEnabled, setSoundEnabled] = useState(
+    () => localStorage.getItem('codetrace-sound') === 'true'
+  );
+
+  const totalSteps = Math.max(leftSteps.length, rightSteps.length);
+
+  const playback = usePlaybackAnimation({ totalSteps, speed });
+
+  // Auto-generate steps when both algorithms are selected or array changes
+  const prevLeftRef = useRef(leftAlgorithm);
+  const prevRightRef = useRef(rightAlgorithm);
+  const prevArrayRef = useRef(array);
+
+  useEffect(() => {
+    const algoChanged = prevLeftRef.current !== leftAlgorithm || prevRightRef.current !== rightAlgorithm;
+    const arrayChanged = prevArrayRef.current !== array;
+    prevLeftRef.current = leftAlgorithm;
+    prevRightRef.current = rightAlgorithm;
+    prevArrayRef.current = array;
+
+    if (!leftAlgorithm || !rightAlgorithm) return;
+    if (!algoChanged && !arrayChanged) return;
+
+    const leftAlgo = algorithms[leftAlgorithm];
+    const rightAlgo = algorithms[rightAlgorithm];
+    if (!leftAlgo || !rightAlgo) return;
+
+    const snapshot = [...array];
+    setLeftSteps(leftAlgo.generate(snapshot) as SortingStep[]);
+    setRightSteps(rightAlgo.generate(snapshot) as SortingStep[]);
+    playback.reset();
+  }, [leftAlgorithm, rightAlgorithm, array, playback]);
+
+  const sizeDebounceRef = useRef<number | null>(null);
+  const handleSizeChange = useCallback((newSize: number) => {
+    playback.reset();
+    setSize(newSize);
+    if (sizeDebounceRef.current !== null) {
+      clearTimeout(sizeDebounceRef.current);
+    }
+    sizeDebounceRef.current = window.setTimeout(() => {
+      generateArray(newSize);
+    }, 300);
+  }, [playback, setSize, generateArray]);
+
+  const handleReset = useCallback(() => {
+    playback.reset();
+  }, [playback]);
+
+  const handleGenerateArray = useCallback((preset?: ArrayPreset) => {
+    generateArray(undefined, preset);
+    setLeftSteps([]);
+    setRightSteps([]);
+    playback.reset();
+  }, [generateArray, playback]);
+
+  const handleSetCustomArray = useCallback((arr: number[]) => {
+    setCustomArray(arr);
+    setLeftSteps([]);
+    setRightSteps([]);
+    playback.reset();
+  }, [setCustomArray, playback]);
+
+  const toggleSound = useCallback(() => {
+    setSoundEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem('codetrace-sound', String(next));
+      return next;
+    });
+  }, []);
+
+  return {
+    leftAlgorithm,
+    rightAlgorithm,
+    setLeftAlgorithm,
+    setRightAlgorithm,
+    array,
+    size,
+    setSize: handleSizeChange,
+    generateArray: handleGenerateArray,
+    setCustomArray: handleSetCustomArray,
+    leftSteps,
+    rightSteps,
+    totalSteps,
+    currentStep: playback.currentStep,
+    isPlaying: playback.isPlaying,
+    play: playback.play,
+    pause: playback.pause,
+    stepForward: playback.stepForward,
+    stepBackward: playback.stepBackward,
+    reset: handleReset,
+    speed,
+    setSpeed,
+    soundEnabled,
+    toggleSound,
+  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,3 +59,11 @@ export interface Algorithm {
 }
 
 export type AlgorithmMode = 'sorting' | 'pathfinding';
+
+export interface ComparisonState {
+  leftAlgorithm: string | null;
+  rightAlgorithm: string | null;
+  array: number[];
+  leftSteps: SortingStep[];
+  rightSteps: SortingStep[];
+}


### PR DESCRIPTION
Introduce a VS mode that lets users race two sorting algorithms on the same input array. Both visualizations share a single playback timeline, with per-algorithm step counters and statistics. The shorter algorithm holds its final sorted frame while the longer one continues.

Closes #22